### PR TITLE
Define `transferRegistry` for transferring a whole registry

### DIFF
--- a/resource-registry/CHANGELOG.md
+++ b/resource-registry/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Revision history of strict-checked-vars
 
+## Next version
+
+* Define `transferRegistry` for moving all resources from one registry to a
+  different one.
+
 ## 0.1.1.0 — 2025-05-15
 
 * Use `io-classes-1.8`.

--- a/resource-registry/src/Control/ResourceRegistry.hs
+++ b/resource-registry/src/Control/ResourceRegistry.hs
@@ -263,11 +263,13 @@ module Control.ResourceRegistry
   , modifyWithTempRegistry
   , runInnerWithTempRegistry
   , runWithTempRegistry
+  , transferRegistry
 
     -- * Unsafe combinators primarily for testing
   , closeRegistry
   , countResources
   , unsafeNewRegistry
+  , resourceKeyId
   ) where
 
 import Control.Applicative ((<|>))
@@ -455,10 +457,17 @@ unlessClosed f = do
 
 -- | Allocate key for new resource
 allocKey :: State (RegistryState m) (Either PrettyCallStack ResourceId)
-allocKey = unlessClosed $ do
+allocKey = unlessClosed $ unsafeAllocKey
+
+unsafeAllocKey :: State (RegistryState m) ResourceId
+unsafeAllocKey = do
   nextKey <- gets registryNextKey
   modify $ \st -> st{registryNextKey = succ nextKey}
   return nextKey
+
+-- | Allocate multiple keys for resources
+allocNKeys :: Int -> State (RegistryState m) (Either PrettyCallStack [ResourceId])
+allocNKeys n = unlessClosed $ replicateM n $ unsafeAllocKey
 
 -- | Insert new resource
 insertResource ::
@@ -584,17 +593,17 @@ unsafeNewRegistry = do
       { registryContext = context
       , registryState = stateVar
       }
- where
-  initState :: RegistryState m
-  initState =
-    RegistryState
-      { registryThreads = KnownThreads Set.empty
-      , registryResources = Map.empty
-      , registryNextKey = ResourceId 1
-      , registryAges = Bimap.empty
-      , registryNextAge = ageOfFirstResource
-      , registryStatus = RegistryOpen
-      }
+
+initState :: RegistryState m
+initState =
+  RegistryState
+    { registryThreads = KnownThreads Set.empty
+    , registryResources = Map.empty
+    , registryNextKey = ResourceId 1
+    , registryAges = Bimap.empty
+    , registryNextAge = ageOfFirstResource
+    , registryStatus = RegistryOpen
+    }
 
 -- | Close the registry
 --
@@ -1528,3 +1537,50 @@ instance
   NoThunks (Bimap k v)
   where
   wNoThunks ctxt = noThunksInKeysAndValues ctxt . Bimap.toList
+
+-- | Move all the resources from the origin registry to the destination
+-- registry and return the list of allocated 'ResourceKey's.
+--
+-- Transferring individual resources between registries is risky because a
+-- later resource in the origin registry might depend on a resource that we are
+-- trying to transfer. However, transferring whole registries is fine.
+transferRegistry ::
+  (MonadSTM m, MonadMask m, MonadThread m, HasCallStack) =>
+  ResourceRegistry m ->
+  ResourceRegistry m ->
+  m [ResourceKey m]
+transferRegistry fromReg toReg = do
+  context <- captureContext
+
+  -- The calling thread is known to the origin registry
+  ensureKnownThread fromReg context
+
+  -- Alloc all the needed keys
+  mKeys <- updateState toReg . allocNKeys =<< countResources fromReg
+
+  case mKeys of
+    -- If the destination registry is closed, throw
+    Left closed -> throwRegistryClosed toReg context closed
+    Right keys -> mask_ $ do
+      -- Get the resources out of the origin registry and empty it
+      regState <- atomically $ swapTVar (registryState fromReg) initState
+
+      forM_
+        ( zip keys $
+            Map.elems (registryResources regState)
+        )
+        ( \(k, res) -> do
+            -- Insert the resources into the new registry
+            inserted <- updateState toReg (insertResource k res)
+
+            case inserted of
+              -- If the destination registry is closed, throw
+              Left closed -> do
+                let Release rel = resourceRelease res
+                void rel
+                throwRegistryClosed toReg context closed
+              Right () ->
+                pure ()
+        )
+
+      pure $ map (ResourceKey toReg) keys


### PR DESCRIPTION
This function allows a registry to be swallowed into another registry.