### PR TITLE
Add upper bound for deepseq

### DIFF
--- a/resource-registry/resource-registry.cabal
+++ b/resource-registry/resource-registry.cabal
@@ -57,7 +57,7 @@ library
     base >=4.14 && <4.23,
     bimap ^>=0.5,
     containers >=0.6.7 && <0.9,
-    deepseq,
+    deepseq ^>=1.4 || ^>=1.5,
     io-classes:{io-classes, strict-stm} >=1.8 && <1.11,
     mtl ^>=2.3,
     nothunks ^>=0.2 || ^>=0.3,


### PR DESCRIPTION
1.6 is deprecated